### PR TITLE
Changed all review request/completion deadlines to be expressed in days

### DIFF
--- a/journal-machinery/ojs-3.0.1/config.inc.php
+++ b/journal-machinery/ojs-3.0.1/config.inc.php
@@ -1,0 +1,480 @@
+; <?php exit(); // DO NOT DELETE ?>
+; DO NOT DELETE THE ABOVE LINE!!!
+; Doing so will expose this configuration file through your web site!
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;
+; config.TEMPLATE.inc.php
+;
+; Copyright (c) 2014-2016 Simon Fraser University Library
+; Copyright (c) 2003-2016 John Willinsky
+; Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+;
+; OJS Configuration settings.
+; Rename config.TEMPLATE.inc.php to config.inc.php to use.
+;
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+;;;;;;;;;;;;;;;;;;;;
+; General Settings ;
+;;;;;;;;;;;;;;;;;;;;
+
+[general]
+
+; Set this to On once the system has been installed
+; (This is generally done automatically by the installer)
+installed = On
+
+; The canonical URL to the OJS installation (excluding the trailing slash)
+base_url = "http://localhost:8888/journal-machinery/ojs-3.0.1/"
+
+; Session cookie name
+session_cookie_name = OJSSID
+
+; Session cookie path; if not specified, defaults to the detected base path
+; session_cookie_path = /
+
+; Number of days to save login cookie for if user selects to remember
+; (set to 0 to force expiration at end of current session)
+session_lifetime = 30
+
+; Enable support for running scheduled tasks
+; Set this to On if you have set up the scheduled tasks script to
+; execute periodically
+scheduled_tasks = On
+
+; Site time zone
+; Please refer to lib/pkp/registry/timeZones.xml for a full list of supported
+; time zones.
+; I.e.:
+; <entry key="Europe/Amsterdam" name="Amsterdam" />
+; time_zone="Amsterdam"
+time_zone = "UTC"
+
+; Short and long date formats
+date_format_trunc = "%m-%d"
+date_format_short = "%Y-%m-%d"
+date_format_long = "%B %e, %Y"
+datetime_format_short = "%Y-%m-%d %I:%M %p"
+datetime_format_long = "%B %e, %Y - %I:%M %p"
+time_format = "%I:%M %p"
+
+; Use URL parameters instead of CGI PATH_INFO. This is useful for
+; broken server setups that don't support the PATH_INFO environment
+; variable.
+disable_path_info = Off
+
+; Use fopen(...) for URL-based reads. Modern versions of dspace
+; will not accept requests using fopen, as it does not provide a
+; User Agent, so this option is disabled by default. If this feature
+; is disabled by PHP's configuration, this setting will be ignored.
+allow_url_fopen = Off
+
+; Base URL override settings: Entries like the following examples can
+; be used to override the base URLs used by OJS. If you want to use a
+; proxy to rewrite URLs to OJS, configure your proxy's URL here.
+; Syntax: base_url[journal_path] = http://www.myUrl.com
+; To override URLs that aren't part of a particular journal, use a
+; journal_path of "index".
+; Examples:
+; base_url[index] = http://www.myUrl.com
+; base_url[myJournal] = http://www.myUrl.com/myJournal
+; base_url[myOtherJournal] = http://myOtherJournal.myUrl.com
+
+; Generate RESTful URLs using mod_rewrite.  This requires the
+; rewrite directive to be enabled in your .htaccess or httpd.conf.
+; See FAQ for more details.
+restful_urls = Off
+
+; Allow the X_FORWARDED_FOR header to override the REMOTE_ADDR as the source IP
+; Set this to "On" if you are behind a reverse proxy and you control the X_FORWARDED_FOR
+; Warning: This defaults to "On" if unset for backwards compatibility.
+trust_x_forwarded_for = Off
+
+; Allow javascript files to be served through a content delivery network (set to off to use local files)
+enable_cdn = On
+
+; Set the maximum number of citation checking processes that may run in parallel.
+; Too high a value can increase server load and lead to too many parallel outgoing
+; requests to citation checking web services. Too low a value can lead to significantly
+; slower citation checking performance. A reasonable value is probably between 3
+; and 10. The more your connection bandwidth allows the better.
+citation_checking_max_processes = 3
+
+; Display a message on the site admin and journal manager user home pages if there is an upgrade available
+show_upgrade_warning = On
+
+; Set the following parameter to off if you want to work with the uncompiled (non-minified) JavaScript
+; source for debugging or if you are working off a development branch without compiled JavaScript.
+enable_minified = On
+
+; Provide a unique site ID and OAI base URL to PKP for statistics and security
+; alert purposes only.
+enable_beacon = 1
+
+
+;;;;;;;;;;;;;;;;;;;;;
+; Database Settings ;
+;;;;;;;;;;;;;;;;;;;;;
+
+[database]
+
+driver = mysql
+host = localhost
+username = root
+password = root
+name = jsamr
+
+; Enable persistent connections
+persistent = Off
+
+; Enable database debug output (very verbose!)
+debug = Off
+
+;;;;;;;;;;;;;;;;;;
+; Cache Settings ;
+;;;;;;;;;;;;;;;;;;
+
+[cache]
+
+; Choose the type of object data caching to use. Options are:
+; - memcache: Use the memcache server configured below
+; - xcache: Use the xcache variable store
+; - apc: Use the APC variable store
+; - none: Use no caching.
+object_cache = none
+
+; Enable memcache support
+memcache_hostname = localhost
+memcache_port = 11211
+
+; For site visitors who are not logged in, many pages are often entirely
+; static (e.g. About, the home page, etc). If the option below is enabled,
+; these pages will be cached in local flat files for the number of hours
+; specified in the web_cache_hours option. This will cut down on server
+; overhead for many requests, but should be used with caution because:
+; 1) Things like journal metadata changes will not be reflected in cached
+;    data until the cache expires or is cleared, and
+; 2) This caching WILL NOT RESPECT DOMAIN-BASED SUBSCRIPTIONS.
+; However, for situations like hosting high-volume open access journals, it's
+; an easy way of decreasing server load.
+;
+; When using web_cache, configure a tool to periodically clear out cache files
+; such as CRON. For example, configure it to run the following command:
+; find .../ojs/cache -maxdepth 1 -name wc-\*.html -mtime +1 -exec rm "{}" ";"
+web_cache = Off
+web_cache_hours = 1
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;
+; Localization Settings ;
+;;;;;;;;;;;;;;;;;;;;;;;;;
+
+[i18n]
+
+; Default locale
+locale = en_US
+
+; Client output/input character set
+client_charset = utf-8
+
+; Database connection character set
+; Must be set to "Off" if not supported by the database server
+; If enabled, must be the same character set as "client_charset"
+; (although the actual name may differ slightly depending on the server)
+connection_charset = Off
+
+; Database storage character set
+; Must be set to "Off" if not supported by the database server
+database_charset = Off
+
+; Enable character normalization to utf-8 (recommended)
+; If disabled, strings will be passed through in their native encoding
+; Note that client_charset and database collation must be set
+; to "utf-8" for this to work, as characters are stored in utf-8
+charset_normalization = Off
+
+;;;;;;;;;;;;;;;;;
+; File Settings ;
+;;;;;;;;;;;;;;;;;
+
+[files]
+
+; Complete path to directory to store uploaded files
+; (This directory should not be directly web-accessible)
+; Windows users should use forward slashes
+files_dir = /Users/helen/Files/git/jnsamr/ojs_uploads
+
+; Path to the directory to store public uploaded files
+; (This directory should be web-accessible and the specified path
+; should be relative to the base OJS directory)
+; Windows users should use forward slashes
+public_files_dir = public
+
+; Permissions mask for created files and directories
+umask = 0022
+
+; The minimum percentage similarity between filenames that should be considered
+; a possible revision
+filename_revision_match = 70
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Fileinfo (MIME) Settings ;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+[finfo]
+; mime_database_path = /etc/magic.mime
+
+
+;;;;;;;;;;;;;;;;;;;;;
+; Security Settings ;
+;;;;;;;;;;;;;;;;;;;;;
+
+[security]
+
+; Force SSL connections site-wide
+force_ssl = Off
+
+; Force SSL connections for login only
+force_login_ssl = Off
+
+; This check will invalidate a session if the user's IP address changes.
+; Enabling this option provides some amount of additional security, but may
+; cause problems for users behind a proxy farm (e.g., AOL).
+session_check_ip = On
+
+; The encryption (hashing) algorithm to use for encrypting user passwords
+; Valid values are: md5, sha1
+; NOTE: This hashing method is deprecated, but necessary to permit gradual
+; migration of old password hashes.
+encryption = sha1
+
+; The unique salt to use for generating password reset hashes
+salt = "YouMustSetASecretKeyHere!!"
+
+; The number of seconds before a password reset hash expires (defaults to 7200 / 2 hours)
+reset_seconds = 7200
+
+; Allowed HTML tags for fields that permit restricted HTML.
+; Use e.g. "img[src,alt],p" to allow "src" and "alt" attributes to the "img"
+; tag, and also to permit the "p" paragraph tag. Unspecified attributes will be
+; stripped.
+allowed_html = "a[href|target|title],em,strong,cite,code,ul,ol,li[class],dl,dt,dd,b,i,u,img[src|alt],sup,sub,br,p"
+
+;Is implicit authentication enabled or not
+
+;implicit_auth = On
+
+;Implicit Auth Header Variables
+
+;implicit_auth_header_first_name = HTTP_GIVENNAME
+;implicit_auth_header_last_name = HTTP_SN
+;implicit_auth_header_email = HTTP_MAIL
+;implicit_auth_header_phone = HTTP_TELEPHONENUMBER
+;implicit_auth_header_initials = HTTP_METADATA_INITIALS
+;implicit_auth_header_mailing_address = HTTP_METADATA_HOMEPOSTALADDRESS
+;implicit_auth_header_uin = HTTP_UID
+
+; A space delimited list of uins to make admin
+;implicit_auth_admin_list = "jdoe@email.ca jshmo@email.ca"
+
+; URL of the implicit auth 'Way Finder' page. See pages/login/LoginHandler.inc.php for usage.
+
+;implicit_auth_wayf_url = "/Shibboleth.sso/wayf"
+
+
+
+;;;;;;;;;;;;;;;;;;
+; Email Settings ;
+;;;;;;;;;;;;;;;;;;
+
+[email]
+
+; Use SMTP for sending mail instead of mail()
+; smtp = On
+
+; SMTP server settings
+; smtp_server = mail.example.com
+; smtp_port = 25
+
+; Enable SMTP authentication
+; Supported mechanisms: ssl, tls
+; smtp_auth = ssl
+; smtp_username = username
+; smtp_password = password
+
+; Allow envelope sender to be specified
+; (may not be possible with some server configurations)
+; allow_envelope_sender = Off
+
+; Default envelope sender to use if none is specified elsewhere
+; default_envelope_sender = my_address@my_host.com
+
+; Force the default envelope sender (if present)
+; This is useful if setting up a site-wide noreply address
+; The reply-to field will be set with the reply-to or from address.
+; force_default_envelope_sender = Off
+
+; Amount of time required between attempts to send non-editorial emails
+; in seconds. This can be used to help prevent email relaying via OJS.
+time_between_emails = 3600
+
+; Maximum number of recipients that can be included in a single email
+; (either as To:, Cc:, or Bcc: addresses) for a non-priveleged user
+max_recipients = 10
+
+; If enabled, email addresses must be validated before login is possible.
+require_validation = Off
+
+; Maximum number of days before an unvalidated account expires and is deleted
+validation_timeout = 14
+
+
+;;;;;;;;;;;;;;;;;;;
+; Search Settings ;
+;;;;;;;;;;;;;;;;;;;
+
+[search]
+
+; Minimum indexed word length
+min_word_length = 3
+
+; The maximum number of search results fetched per keyword. These results
+; are fetched and merged to provide results for searches with several keywords.
+results_per_keyword = 500
+
+; The number of hours for which keyword search results are cached.
+result_cache_hours = 1
+
+; Paths to helper programs for indexing non-text files.
+; Programs are assumed to output the converted text to stdout, and "%s" is
+; replaced by the file argument.
+; Note that using full paths to the binaries is recommended.
+; Uncomment applicable lines to enable (at most one per file type).
+; Additional "index[MIME_TYPE]" lines can be added for any mime type to be
+; indexed.
+
+; PDF
+; index[application/pdf] = "/usr/bin/pstotext -enc UTF-8 -nopgbrk %s - | /usr/bin/tr '[:cntrl:]' ' '"
+; index[application/pdf] = "/usr/bin/pdftotext -enc UTF-8 -nopgbrk %s - | /usr/bin/tr '[:cntrl:]' ' '"
+
+; PostScript
+; index[application/postscript] = "/usr/bin/pstotext -enc UTF-8 -nopgbrk %s - | /usr/bin/tr '[:cntrl:]' ' '"
+; index[application/postscript] = "/usr/bin/ps2ascii %s | /usr/bin/tr '[:cntrl:]' ' '"
+
+; Microsoft Word
+; index[application/msword] = "/usr/bin/antiword %s"
+; index[application/msword] = "/usr/bin/catdoc %s"
+
+
+;;;;;;;;;;;;;;;;
+; OAI Settings ;
+;;;;;;;;;;;;;;;;
+
+[oai]
+
+; Enable OAI front-end to the site
+oai = On
+
+; OAI Repository identifier
+repository_id = "ojs2.localhost:8888"
+
+; Maximum number of records per request to serve via OAI
+oai_max_records = 100
+
+;;;;;;;;;;;;;;;;;;;;;;
+; Interface Settings ;
+;;;;;;;;;;;;;;;;;;;;;;
+
+[interface]
+
+; Number of items to display per page; overridable on a per-journal basis
+items_per_page = 25
+
+; Number of page links to display; overridable on a per-journal basis
+page_links = 10
+
+
+;;;;;;;;;;;;;;;;;;;;
+; Captcha Settings ;
+;;;;;;;;;;;;;;;;;;;;
+
+[captcha]
+
+; Whether or not to enable ReCaptcha
+recaptcha = off
+
+; Public key for reCaptcha (see http://www.google.com/recaptcha)
+recaptcha_public_key = your_public_key
+
+; Private key for reCaptcha (see http://www.google.com/recaptcha)
+recaptcha_private_key = your_private_key
+
+; Whether or not to use Captcha on user registration
+captcha_on_register = on
+
+
+;;;;;;;;;;;;;;;;;;;;;
+; External Commands ;
+;;;;;;;;;;;;;;;;;;;;;
+
+[cli]
+
+; These are paths to (optional) external binaries used in
+; certain plug-ins or advanced program features.
+
+; Using full paths to the binaries is recommended.
+
+; perl (used in paracite citation parser)
+perl = /usr/bin/perl
+
+; tar (used in backup plugin, translation packaging)
+tar = /bin/tar
+
+; On systems that do not have libxsl/xslt libraries installed, or for those who
+; require a specific XSLT processor, you may enter the complete path to the
+; XSLT renderer tool, with any required arguments. Use %xsl to substitute the
+; location of the XSL stylesheet file, and %xml for the location of the XML
+; source file; eg:
+; /usr/bin/java -jar ~/java/xalan.jar -HTML -IN %xml -XSL %xsl
+xslt_command = ""
+
+;;;;;;;;;;;;;;;;;;
+; Proxy Settings ;
+;;;;;;;;;;;;;;;;;;
+
+[proxy]
+
+; Note that allow_url_fopen must be set to Off before these proxy settings
+; will take effect.
+
+; The HTTP proxy configuration to use
+; http_host = localhost
+; http_port = 80
+; proxy_username = username
+; proxy_password = password
+
+
+;;;;;;;;;;;;;;;;;;
+; Debug Settings ;
+;;;;;;;;;;;;;;;;;;
+
+[debug]
+
+; Display a stack trace when a fatal error occurs.
+; Note that this may expose private information and should be disabled
+; for any production system.
+show_stacktrace = Off
+
+; Display an error message when something goes wrong.
+display_errors = Off
+
+; Display deprecation warnings
+deprecation_warnings = Off
+
+; Log web service request information for debugging
+log_web_service_info = Off

--- a/journal-machinery/ojs-3.0.1/plugins/themes/nsamr/classes/submission/action/EditorAction.inc.php
+++ b/journal-machinery/ojs-3.0.1/plugins/themes/nsamr/classes/submission/action/EditorAction.inc.php
@@ -1,0 +1,300 @@
+<?php
+
+/**
+ * @file classes/submission/action/EditorAction.inc.php
+ *
+ * Copyright (c) 2014-2016 Simon Fraser University Library
+ * Copyright (c) 2003-2016 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @class EditorAction
+ * @ingroup submission_action
+ *
+ * @brief Editor actions.
+ */
+
+// Access decision actions constants.
+import('classes.workflow.EditorDecisionActionsManager');
+
+class EditorAction {
+	/**
+	 * Constructor.
+	 */
+	function __construct() {
+	}
+
+	//
+	// Actions.
+	//
+	/**
+	 * Records an editor's submission decision.
+	 * @param $request PKPRequest
+	 * @param $submission Submission
+	 * @param $decision integer
+	 * @param $decisionLabels array(DECISION_CONSTANT => decision.locale.key, ...)
+	 * @param $reviewRound ReviewRound Current review round that user is taking the decision, if any.
+	 * @param $stageId int
+	 */
+	function recordDecision($request, $submission, $decision, $decisionLabels, $reviewRound = null, $stageId = null) {
+		$stageAssignmentDao = DAORegistry::getDAO('StageAssignmentDAO');
+
+		// Define the stage and round data.
+		if (!is_null($reviewRound)) {
+			$stageId = $reviewRound->getStageId();
+		} else {
+			if ($stageId == null) {
+				// We consider that the decision is being made for the current
+				// submission stage.
+				$stageId = $submission->getStageId();
+			}
+		}
+
+		$editorAssigned = $stageAssignmentDao->editorAssignedToStage(
+			$submission->getId(),
+			$stageId
+		);
+
+		// Sanity checks
+		if (!$editorAssigned || !isset($decisionLabels[$decision])) return false;
+
+		$user = $request->getUser();
+		$editorDecision = array(
+			'editDecisionId' => null,
+			'editorId' => $user->getId(),
+			'decision' => $decision,
+			'dateDecided' => date(Core::getCurrentDate())
+		);
+
+		$result = $editorDecision;
+		if (!HookRegistry::call('EditorAction::recordDecision', array(&$submission, &$editorDecision, &$result))) {
+			// Record the new decision
+			$editDecisionDao = DAORegistry::getDAO('EditDecisionDAO');
+			$editDecisionDao->updateEditorDecision($submission->getId(), $editorDecision, $stageId, $reviewRound);
+
+			// Stamp the submission modified
+			$submission->stampStatusModified();
+			$submissionDao = Application::getSubmissionDAO();
+			$submissionDao->updateObject($submission);
+
+			// Add log entry
+			import('lib.pkp.classes.log.SubmissionLog');
+			import('lib.pkp.classes.log.PKPSubmissionEventLogEntry');
+			AppLocale::requireComponents(LOCALE_COMPONENT_APP_COMMON, LOCALE_COMPONENT_APP_EDITOR);
+			SubmissionLog::logEvent($request, $submission, SUBMISSION_LOG_EDITOR_DECISION, 'log.editor.decision', array('editorName' => $user->getFullName(), 'submissionId' => $submission->getId(), 'decision' => __($decisionLabels[$decision])));
+		}
+		return $result;
+	}
+
+	/**
+	 * Clears a review assignment from a submission.
+	 * @param $request PKPRequest
+	 * @param $submission object
+	 * @param $reviewId int
+	 */
+	function clearReview($request, $submissionId, $reviewId) {
+		$submissionDao = Application::getSubmissionDAO();
+		$submission = $submissionDao->getById($submissionId);
+		$reviewAssignmentDao = DAORegistry::getDAO('ReviewAssignmentDAO');
+		$userDao = DAORegistry::getDAO('UserDAO');
+
+		$reviewAssignment = $reviewAssignmentDao->getById($reviewId);
+
+		if (isset($reviewAssignment) && $reviewAssignment->getSubmissionId() == $submission->getId() && !HookRegistry::call('EditorAction::clearReview', array(&$submission, $reviewAssignment))) {
+			$reviewer = $userDao->getById($reviewAssignment->getReviewerId());
+			if (!isset($reviewer)) return false;
+			$reviewAssignmentDao->deleteById($reviewId);
+
+			// Stamp the modification date
+			$submission->stampModified();
+			$submissionDao->updateObject($submission);
+
+			$notificationDao = DAORegistry::getDAO('NotificationDAO');
+			$notificationDao->deleteByAssoc(
+				ASSOC_TYPE_REVIEW_ASSIGNMENT,
+				$reviewAssignment->getId(),
+				$reviewAssignment->getReviewerId(),
+				NOTIFICATION_TYPE_REVIEW_ASSIGNMENT
+			);
+
+			// Insert a trivial notification to indicate the reviewer was removed successfully.
+			$currentUser = $request->getUser();
+			$notificationMgr = new NotificationManager();
+			$notificationMgr->createTrivialNotification($currentUser->getId(), NOTIFICATION_TYPE_SUCCESS, array('contents' => __('notification.removedReviewer')));
+
+			// Update the review round status, if needed.
+			$reviewRoundDao = DAORegistry::getDAO('ReviewRoundDAO');
+			$reviewRound = $reviewRoundDao->getById($reviewAssignment->getReviewRoundId());
+			$reviewAssignments = $reviewAssignmentDao->getBySubmissionId($reviewRound->getSubmissionId(), $reviewRound->getId(), $reviewRound->getStageId());
+			$reviewRoundDao->updateStatus($reviewRound, $reviewAssignments);
+
+			$notificationMgr->updateNotification(
+				$request,
+				array(NOTIFICATION_TYPE_ALL_REVIEWS_IN),
+				null,
+				ASSOC_TYPE_REVIEW_ROUND,
+				$reviewRound->getId()
+			);
+
+			// Add log
+			import('lib.pkp.classes.log.SubmissionLog');
+			import('classes.log.SubmissionEventLogEntry');
+			SubmissionLog::logEvent($request, $submission, SUBMISSION_LOG_REVIEW_CLEAR, 'log.review.reviewCleared', array('reviewerName' => $reviewer->getFullName(), 'submissionId' => $submission->getId(), 'stageId' => $reviewAssignment->getStageId(), 'round' => $reviewAssignment->getRound()));
+
+			return true;
+		} else return false;
+	}
+
+	/**
+	 * Assigns a reviewer to a submission.
+	 * @param $request PKPRequest
+	 * @param $submission object
+	 * @param $reviewerId int
+	 * @param $reviewRound ReviewRound
+	 * @param $reviewDueDate datetime optional
+	 * @param $responseDueDate datetime optional
+	 */
+	function addReviewer($request, $submission, $reviewerId, &$reviewRound, $reviewDueDate = null, $responseDueDate = null, $reviewMethod = null) {
+		$reviewAssignmentDao = DAORegistry::getDAO('ReviewAssignmentDAO');
+		$userDao = DAORegistry::getDAO('UserDAO');
+
+		$reviewer = $userDao->getById($reviewerId);
+
+		// Check to see if the requested reviewer is not already
+		// assigned to review this submission.
+
+		$assigned = $reviewAssignmentDao->reviewerExists($reviewRound->getId(), $reviewerId);
+
+		// Only add the reviewer if he has not already
+		// been assigned to review this submission.
+		$stageId = $reviewRound->getStageId();
+		$round = $reviewRound->getRound();
+		if (!$assigned && isset($reviewer) && !HookRegistry::call('EditorAction::addReviewer', array(&$submission, $reviewerId))) {
+			$reviewAssignment = new ReviewAssignment();
+			$reviewAssignment->setSubmissionId($submission->getId());
+			$reviewAssignment->setReviewerId($reviewerId);
+			$reviewAssignment->setDateAssigned(Core::getCurrentDate());
+			$reviewAssignment->setStageId($stageId);
+			$reviewAssignment->setRound($round);
+			$reviewAssignment->setReviewRoundId($reviewRound->getId());
+			if (isset($reviewMethod)) {
+				$reviewAssignment->setReviewMethod($reviewMethod);
+			}
+			$reviewAssignmentDao->insertObject($reviewAssignment);
+
+			// Stamp modification date
+			$submission->stampStatusModified();
+			$submissionDao = Application::getSubmissionDAO();
+			$submissionDao->updateObject($submission);
+
+			$this->setDueDates($request, $submission, $reviewAssignment, $reviewDueDate, $responseDueDate);
+
+			// Add notification
+			$notificationMgr = new NotificationManager();
+			$notificationMgr->createNotification(
+				$request,
+				$reviewerId,
+				NOTIFICATION_TYPE_REVIEW_ASSIGNMENT,
+				$submission->getContextId(),
+				ASSOC_TYPE_REVIEW_ASSIGNMENT,
+				$reviewAssignment->getId(),
+				NOTIFICATION_LEVEL_TASK,
+				null,
+				true
+			);
+
+			// Insert a trivial notification to indicate the reviewer was added successfully.
+			$currentUser = $request->getUser();
+			$notificationMgr = new NotificationManager();
+			$notificationMgr->createTrivialNotification($currentUser->getId(), NOTIFICATION_TYPE_SUCCESS, array('contents' => __('notification.addedReviewer')));
+
+			// Update the review round status.
+			$reviewRoundDao = DAORegistry::getDAO('ReviewRoundDAO'); /* @var $reviewRoundDao ReviewRoundDAO */
+			$reviewAssignments = $reviewAssignmentDao->getBySubmissionId($submission->getId(), $reviewRound->getId(), $stageId);
+			$reviewRoundDao->updateStatus($reviewRound, $reviewAssignments);
+
+			$notificationMgr->updateNotification(
+				$request,
+				array(NOTIFICATION_TYPE_ALL_REVIEWS_IN),
+				null,
+				ASSOC_TYPE_REVIEW_ROUND,
+				$reviewRound->getId()
+			);
+
+			// Add log
+			import('lib.pkp.classes.log.SubmissionLog');
+			import('lib.pkp.classes.log.PKPSubmissionEventLogEntry');
+			SubmissionLog::logEvent($request, $submission, SUBMISSION_LOG_REVIEW_ASSIGN, 'log.review.reviewerAssigned', array('reviewerName' => $reviewer->getFullName(), 'submissionId' => $submission->getId(), 'stageId' => $stageId, 'round' => $round));
+		}
+	}
+
+	/**
+	 * Sets the due date for a review assignment.
+	 * @param $request PKPRequest
+	 * @param $submission Submission
+	 * @param $reviewId int
+	 * @param $dueDate string
+	 * @param $numWeeks int
+	 * @param $logEntry boolean
+	 */
+	function setDueDates($request, $submission, $reviewAssignment, $reviewDueDate = null, $responseDueDate = null, $logEntry = false) {
+		$userDao = DAORegistry::getDAO('UserDAO');
+		$context = $request->getContext();
+
+		$reviewer = $userDao->getById($reviewAssignment->getReviewerId());
+		if (!isset($reviewer)) return false;
+
+		if ($reviewAssignment->getSubmissionId() == $submission->getId() && !HookRegistry::call('EditorAction::setDueDates', array(&$reviewAssignment, &$reviewer, &$reviewDueDate, &$responseDueDate))) {
+
+			// Set the review due date
+			$defaultNumWeeks = $context->getSetting('numWeeksPerReview');
+			$reviewAssignment->setDateDue(DAO::formatDateToDB($reviewDueDate, $defaultNumWeeks, false));
+
+			// Set the response due date
+			$defaultNumWeeks = $context->getSetting('numWeeksPerReponse');
+			$reviewAssignment->setDateResponseDue(DAO::formatDateToDB($responseDueDate, $defaultNumWeeks, false));
+
+			// update the assignment (with both the new dates)
+			$reviewAssignment->stampModified();
+			$reviewAssignmentDao = DAORegistry::getDAO('ReviewAssignmentDAO'); /* @var $reviewAssignmentDao ReviewAssignmentDAO */
+			$reviewAssignmentDao->updateObject($reviewAssignment);
+
+			// N.B. Only logging Date Due
+			if ($logEntry) {
+				// Add log
+				import('lib.pkp.classes.log.SubmissionLog');
+				import('classes.log.SubmissionEventLogEntry');
+				SubmissionLog::logEvent(
+					$request,
+					$submission,
+					SUBMISSION_LOG_REVIEW_SET_DUE_DATE,
+					'log.review.reviewDueDateSet',
+					array(
+						'reviewerName' => $reviewer->getFullName(),
+						'dueDate' => strftime(
+							Config::getVar('general', 'date_format_short'),
+							strtotime($reviewAssignment->getDateDue())
+						),
+						'submissionId' => $submission->getId(),
+						'stageId' => $reviewAssignment->getStageId(),
+						'round' => $reviewAssignment->getRound()
+					)
+				);
+			}
+		}
+	}
+
+	/**
+	 * Increment a submission's workflow stage.
+	 * @param $submission Submission
+	 * @param $newStage integer One of the WORKFLOW_STAGE_* constants.
+	 * @param $request Request
+	 */
+	function incrementWorkflowStage($submission, $newStage, $request) {
+		// Change the submission's workflow stage.
+		$submission->setStageId($newStage);
+		$submissionDao = Application::getSubmissionDAO();
+		$submissionDao->updateObject($submission);
+	}
+}
+
+?>

--- a/journal-machinery/ojs-3.0.1/plugins/themes/nsamr/classes/submission/action/EditorAction.inc.php
+++ b/journal-machinery/ojs-3.0.1/plugins/themes/nsamr/classes/submission/action/EditorAction.inc.php
@@ -233,7 +233,7 @@ class EditorAction {
 	 * @param $submission Submission
 	 * @param $reviewId int
 	 * @param $dueDate string
-	 * @param $numWeeks int
+	 * @param $numWeeks int // TODO This is now actually expressed and handled in days
 	 * @param $logEntry boolean
 	 */
 	function setDueDates($request, $submission, $reviewAssignment, $reviewDueDate = null, $responseDueDate = null, $logEntry = false) {

--- a/journal-machinery/ojs-3.0.1/plugins/themes/nsamr/classes/task/ReviewReminder.inc.php
+++ b/journal-machinery/ojs-3.0.1/plugins/themes/nsamr/classes/task/ReviewReminder.inc.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * @file classes/task/ReviewReminder.inc.php
+ *
+ * Copyright (c) 2013-2016 Simon Fraser University Library
+ * Copyright (c) 2003-2016 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @class ReviewReminder
+ * @ingroup tasks
+ *
+ * @brief Class to perform automated reminders for reviewers.
+ */
+
+import('lib.pkp.classes.scheduledTask.ScheduledTask');
+
+define('REVIEW_REMIND_AUTO', 'REVIEW_REMIND_AUTO');
+define('REVIEW_REQUEST_REMIND_AUTO', 'REVIEW_REQUEST_REMIND_AUTO');
+
+class ReviewReminder extends ScheduledTask {
+
+	/**
+	 * Constructor.
+	 */
+	function __construct() {
+		parent::__construct();
+	}
+
+	/**
+	 * @copydoc ScheduledTask::getName()
+	 */
+	function getName() {
+		return __('admin.scheduledTask.reviewReminder');
+	}
+
+	/**
+	 * Send the automatic review reminder to the reviewer.
+	 * @param $reviewAssignment ReviewAssignment
+	 * @param $submission Submission
+	 * @param $context Context
+	 * @param $reminderType string
+	 * 	REVIEW_REMIND_AUTO, REVIEW_REQUEST_REMIND_AUTO
+	 */
+	function sendReminder ($reviewAssignment, $submission, $context, $reminderType = REVIEW_REMIND_AUTO) {
+		$reviewAssignmentDao = DAORegistry::getDAO('ReviewAssignmentDAO');
+		$userDao = DAORegistry::getDAO('UserDAO');
+		$reviewId = $reviewAssignment->getId();
+
+		$reviewer = $userDao->getById($reviewAssignment->getReviewerId());
+		if (!isset($reviewer)) return false;
+
+		import('lib.pkp.classes.mail.SubmissionMailTemplate');
+		$emailKey = $reminderType;
+		$reviewerAccessKeysEnabled = $context->getSetting('reviewerAccessKeysEnabled');
+		switch (true) {
+			case $reviewerAccessKeysEnabled && ($reminderType == REVIEW_REMIND_AUTO):
+				$emailKey = 'REVIEW_REMIND_AUTO_ONECLICK';
+				break;
+			case $reviewerAccessKeysEnabled && ($reminderType == REVIEW_REQUEST_REMIND_AUTO):
+				$emailKey = 'REVIEW_REQUEST_REMIND_AUTO_ONECLICK';
+				break;
+		}
+		$email = new SubmissionMailTemplate($submission, $emailKey, $context->getPrimaryLocale(), $context, false);
+		$email->setContext($context);
+		$email->setReplyTo(null);
+		$email->addRecipient($reviewer->getEmail(), $reviewer->getFullName());
+		$email->setSubject($email->getSubject($context->getPrimaryLocale()));
+		$email->setBody($email->getBody($context->getPrimaryLocale()));
+
+		$urlParams = array(
+			'submissionId' => $reviewAssignment->getSubmissionId(),
+		);
+		if ($reviewerAccessKeysEnabled) {
+			import('lib.pkp.classes.security.AccessKeyManager');
+			$accessKeyManager = new AccessKeyManager();
+
+			// Key lifetime is the typical review period plus four weeks
+			$keyLifetime = ($context->getSetting('numWeeksPerReview') + 4) * 7;
+			$urlParams['key'] = $accessKeyManager->createKey('ReviewerContext', $reviewer->getId(), $reviewId, $keyLifetime);
+		}
+		$application = PKPApplication::getApplication();
+		$request = $application->getRequest();
+		$dispatcher = $application->getDispatcher();
+		$submissionReviewUrl = $dispatcher->url($request, ROUTE_PAGE, $context->getPath(), 'reviewer', 'submission', null, $urlParams);
+
+		// Format the review due date
+		$reviewDueDate = strtotime($reviewAssignment->getDateDue());
+		$dateFormatShort = Config::getVar('general', 'date_format_short');
+		if ($reviewDueDate === -1 || $reviewDueDate === false) {
+			// Default to something human-readable if no date specified
+			$reviewDueDate = '_____';
+		} else {
+			$reviewDueDate = strftime($dateFormatShort, $reviewDueDate);
+		}
+		// Format the review response due date
+		$responseDueDate = strtotime($reviewAssignment->getDateResponseDue());
+		if ($responseDueDate === -1 || $responseDueDate === false) {
+			// Default to something human-readable if no date specified
+			$responseDueDate = '_____';
+		} else {
+			$responseDueDate = strftime($dateFormatShort, $responseDueDate);
+		}
+
+		AppLocale::requireComponents(LOCALE_COMPONENT_PKP_REVIEWER);
+		AppLocale::requireComponents(LOCALE_COMPONENT_PKP_COMMON);
+		$paramArray = array(
+			'reviewerName' => $reviewer->getFullName(),
+			'reviewerUserName' => $reviewer->getUsername(),
+			'reviewDueDate' => $reviewDueDate,
+			'responseDueDate' => $responseDueDate,
+			'editorialContactSignature' => $context->getSetting('contactName') . "\n" . $context->getLocalizedName(),
+			'passwordResetUrl' => $dispatcher->url($request, ROUTE_PAGE, $context->getPath(), 'login', 'resetPassword', $reviewer->getUsername(), array('confirm' => Validation::generatePasswordResetHash($reviewer->getId()))),
+			'submissionReviewUrl' => $submissionReviewUrl,
+			'messageToReviewer' => __('reviewer.step1.requestBoilerplate'),
+			'abstractTermIfEnabled' => ($submission->getLocalizedAbstract() == '' ? '' : __('common.abstract')),
+		);
+		$email->assignParams($paramArray);
+
+		$email->send();
+
+		$reviewAssignment->setDateReminded(Core::getCurrentDate());
+		$reviewAssignment->setReminderWasAutomatic(1);
+		$reviewAssignmentDao->updateObject($reviewAssignment);
+
+	}
+
+	/**
+	 * @copydoc ScheduledTask::executeActions()
+	 */
+	function executeActions() {
+		$submission = null;
+		$context = null;
+
+		$reviewAssignmentDao = DAORegistry::getDAO('ReviewAssignmentDAO');
+		$submissionDao = Application::getSubmissionDAO();
+		$contextDao = Application::getContextDAO();
+
+		$incompleteAssignments = $reviewAssignmentDao->getIncompleteReviewAssignments();
+		$inviteReminderDays = $submitReminderDays = null;
+		foreach ($incompleteAssignments as $reviewAssignment) {
+			// Avoid review assignments that a reminder exists for.
+			if ($reviewAssignment->getDateReminded() !== null) continue;
+
+			// Fetch the submission and the context.
+			if ($submission == null || $submission->getId() != $reviewAssignment->getSubmissionId()) {
+				unset($submission);
+				$submission = $submissionDao->getById($reviewAssignment->getSubmissionId());
+				// Avoid review assignments without submission in database.
+				if (!$submission) continue;
+
+				if ($submission->getStatus() != STATUS_QUEUED) continue;
+
+				if ($context == null || $context->getId() != $submission->getContextId()) {
+					unset($context);
+					$context = $contextDao->getById($submission->getContextId());
+
+					$inviteReminderDays = $context->getSetting('numDaysBeforeInviteReminder');
+					$submitReminderDays = $context->getSetting('numDaysBeforeSubmitReminder');
+				}
+			}
+
+			$reminderType = false;
+			if ($submitReminderDays>=1 && $reviewAssignment->getDateDue() != null) {
+				$checkDate = strtotime($reviewAssignment->getDateDue());
+				if (time() - $checkDate > 60 * 60 * 24 * $submitReminderDays) {
+					$reminderType = REVIEW_REMIND_AUTO;
+				}
+			}
+			if ($inviteReminderDays>=1 && $reviewAssignment->getDateConfirmed() == null) {
+				$checkDate = strtotime($reviewAssignment->getDateResponseDue());
+				if (time() - $checkDate > 60 * 60 * 24 * $inviteReminderDays) {
+					$reminderType = REVIEW_REQUEST_REMIND_AUTO;
+				}
+			}
+
+			if ($reminderType) $this->sendReminder ($reviewAssignment, $submission, $context, $reminderType);
+		}
+
+		return true;
+	}
+}
+
+?>

--- a/journal-machinery/ojs-3.0.1/plugins/themes/nsamr/controllers/grid/users/reviewer/form/ReviewerForm.inc.php
+++ b/journal-machinery/ojs-3.0.1/plugins/themes/nsamr/controllers/grid/users/reviewer/form/ReviewerForm.inc.php
@@ -1,0 +1,468 @@
+<?php
+
+/**
+ * @file controllers/grid/users/reviewer/form/ReviewerForm.inc.php
+ *
+ * Copyright (c) 2014-2016 Simon Fraser University Library
+ * Copyright (c) 2003-2016 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @class ReviewerForm
+ * @ingroup controllers_grid_users_reviewer_form
+ *
+ * @brief Base Form for adding a reviewer to a submission.
+ * N.B. Requires a subclass to implement the "reviewerId" to be added.
+ */
+
+import('lib.pkp.classes.form.Form');
+
+class ReviewerForm extends Form {
+	/** The submission associated with the review assignment **/
+	var $_submission;
+
+	/** The review round associated with the review assignment **/
+	var $_reviewRound;
+
+	/** An array of actions for the other reviewer forms */
+	var $_reviewerFormActions;
+
+	/** An array with all current user roles */
+	var $_userRoles;
+
+	/**
+	 * Constructor.
+	 * @param $submission Submission
+	 * @param $reviewRound ReviewRound
+	 */
+	function __construct($submission, $reviewRound) {
+		parent::__construct('controllers/grid/users/reviewer/form/defaultReviewerForm.tpl');
+		$this->setSubmission($submission);
+		$this->setReviewRound($reviewRound);
+
+		// Validation checks for this form
+		$this->addCheck(new FormValidator($this, 'responseDueDate', 'required', 'editor.review.errorAddingReviewer'));
+		$this->addCheck(new FormValidator($this, 'reviewDueDate', 'required', 'editor.review.errorAddingReviewer'));
+
+		$this->addCheck(new FormValidatorPost($this));
+		$this->addCheck(new FormValidatorCSRF($this));
+
+		import('lib.pkp.classes.mail.SubmissionMailTemplate');
+	}
+
+	//
+	// Getters and Setters
+	//
+	/**
+	 * Get the submission Id
+	 * @return int submissionId
+	 */
+	function getSubmissionId() {
+		$submission = $this->getSubmission();
+		return $submission->getId();
+	}
+
+	/**
+	 * Get the submission
+	 * @return Submission
+	 */
+	function getSubmission() {
+		return $this->_submission;
+	}
+
+	/**
+	 * Get the ReviewRound
+	 * @return ReviewRound
+	 */
+	function getReviewRound() {
+		return $this->_reviewRound;
+	}
+
+	/**
+	 * Set the submission
+	 * @param $submission Submission
+	 */
+	function setSubmission($submission) {
+		$this->_submission = $submission;
+	}
+
+	/**
+	 * Set the ReviewRound
+	 * @param $reviewRound ReviewRound
+	 */
+	function setReviewRound($reviewRound) {
+		$this->_reviewRound = $reviewRound;
+	}
+
+	/**
+	 * Set a reviewer form action
+	 * @param $action LinkAction
+	 */
+	function setReviewerFormAction($action) {
+		$this->_reviewerFormActions[$action->getId()] = $action;
+	}
+
+	/**
+	 * Set current user roles.
+	 * @param $userRoles Array
+	 */
+	function setUserRoles($userRoles) {
+		$this->_userRoles = $userRoles;
+	}
+
+	/**
+	 * Get current user roles.
+	 * @return $userRoles Array
+	 */
+	function getUserRoles() {
+		return $this->_userRoles;
+	}
+
+	/**
+	 * Get all of the reviewer form actions
+	 * @return array
+	 */
+	function getReviewerFormActions() {
+		return $this->_reviewerFormActions;
+	}
+	//
+	// Overridden template methods
+	//
+	/**
+	 * Initialize form data from the associated author.
+	 * @param $args array
+	 * @param $request PKPRequest
+	 */
+	function initData($args, $request) {
+		$reviewerId = (int) $request->getUserVar('reviewerId');
+		$context = $request->getContext();
+		$reviewRound = $this->getReviewRound();
+		$submission = $this->getSubmission();
+
+		// The reviewer id has been set
+		if (!empty($reviewerId)) {
+			if ($this->_isValidReviewer($context, $submission, $reviewRound, $reviewerId)) {
+				$userDao = DAORegistry::getDAO('UserDAO'); /* @var $userDao UserDAO */
+				$reviewer = $userDao->getById($reviewerId);
+				$this->setData('userNameString', sprintf('%s (%s)', $reviewer->getFullname(), $reviewer->getUsername()));
+			}
+		}
+
+		// Get review assignment related data;
+		$reviewAssignmentDao = DAORegistry::getDAO('ReviewAssignmentDAO');
+		$reviewAssignment = $reviewAssignmentDao->getReviewAssignment($reviewRound->getId(), $reviewerId, $reviewRound->getRound());
+
+		// Get the review method (open, blind, or double-blind)
+		if (isset($reviewAssignment) && $reviewAssignment->getReviewMethod() != false) {
+			$reviewMethod = $reviewAssignment->getReviewMethod();
+			$reviewFormId = $reviewAssignment->getReviewFormId();
+		} else {
+			// Set default review method.
+			$reviewMethod = $context->getSetting('defaultReviewMode');
+			if (!$reviewMethod) $reviewMethod = SUBMISSION_REVIEW_METHOD_BLIND;
+
+			// If there is a section/series and it has a default
+			// review form designated, use it.
+			$sectionDao = Application::getSectionDAO();
+			$section = $sectionDao->getById($submission->getSectionId(), $context->getId());
+			if ($section) $reviewFormId = $section->getReviewFormId();
+			else $reviewFormId = null;
+		}
+
+		// Get the response/review due dates or else set defaults
+		if (isset($reviewAssignment) && $reviewAssignment->getDueDate() != null) {
+			$reviewDueDate = strftime(Config::getVar('general', 'date_format_short'), strtotime($reviewAssignment->getDueDate()));
+		} else {
+			$numWeeks = (int) $context->getSetting('numWeeksPerReview');
+			if ($numWeeks<=0) $numWeeks=4;
+			$reviewDueDate = strftime(Config::getVar('general', 'date_format_short'), strtotime('+' . $numWeeks . ' week'));
+		}
+		if (isset($reviewAssignment) && $reviewAssignment->getResponseDueDate() != null) {
+			$responseDueDate = strftime(Config::getVar('general', 'date_format_short'), strtotime($reviewAssignment->getResponseDueDate()));
+		} else {
+			$numWeeks = (int) $context->getSetting('numWeeksPerResponse');
+			if ($numWeeks<=0) $numWeeks=3;
+			$responseDueDate = strftime(Config::getVar('general', 'date_format_short'), strtotime('+' . $numWeeks . ' week'));
+		}
+
+		// Get the currently selected reviewer selection type to show the correct tab if we're re-displaying the form
+		$selectionType = (int) $request->getUserVar('selectionType');
+		$stageId = $reviewRound->getStageId();
+
+		$this->setData('submissionId', $this->getSubmissionId());
+		$this->setData('stageId', $stageId);
+		$this->setData('reviewMethod', $reviewMethod);
+		$this->setData('reviewFormId', $reviewFormId);
+		$this->setData('reviewRoundId', $reviewRound->getId());
+		$this->setData('reviewerId', $reviewerId);
+
+		$context = $request->getContext();
+		$templateKey = $this->_getMailTemplateKey($context);
+		$template = new SubmissionMailTemplate($submission, $templateKey);
+		if ($template) {
+			$user = $request->getUser();
+			$dispatcher = $request->getDispatcher();
+			AppLocale::requireComponents(LOCALE_COMPONENT_PKP_REVIEWER); // reviewer.step1.requestBoilerplate
+			$template->assignParams(array(
+				'contextUrl' => $dispatcher->url($request, ROUTE_PAGE, $context->getPath()),
+				'editorialContactSignature' => $user->getContactSignature(),
+				'signatureFullName' => $user->getFullname(),
+				'passwordResetUrl' => $dispatcher->url($request, ROUTE_PAGE, $context->getPath(), 'login', 'lostPassword'),
+				'messageToReviewer' => __('reviewer.step1.requestBoilerplate'),
+				'abstractTermIfEnabled' => ($submission->getLocalizedAbstract() == '' ? '' : __('common.abstract')), // Deprecated; for OJS 2.x templates
+			));
+			$template->replaceParams();
+		}
+		$this->setData('personalMessage', $template->getBody());
+		$this->setData('responseDueDate', $responseDueDate);
+		$this->setData('reviewDueDate', $reviewDueDate);
+		$this->setData('selectionType', $selectionType);
+	}
+
+	/**
+	 * @copydoc Form::fetch()
+	 */
+	function fetch($request) {
+		$context = $request->getContext();
+
+		// Get the review method options.
+		$reviewAssignmentDao = DAORegistry::getDAO('ReviewAssignmentDAO');
+		$reviewMethods = $reviewAssignmentDao->getReviewMethodsTranslationKeys();
+		$submission = $this->getSubmission();
+
+		$templateMgr = TemplateManager::getManager($request);
+		$templateMgr->assign('reviewMethods', $reviewMethods);
+		$templateMgr->assign('reviewerActions', $this->getReviewerFormActions());
+		$reviewFormDao = DAORegistry::getDAO('ReviewFormDAO');
+		$reviewForms = array(0 => __('editor.article.selectReviewForm'));
+		$reviewFormsIterator = $reviewFormDao->getActiveByAssocId(Application::getContextAssocType(), $context->getId());
+		while ($reviewForm = $reviewFormsIterator->next()) {
+			$reviewForms[$reviewForm->getId()] = $reviewForm->getLocalizedTitle();
+		}
+		$templateMgr->assign('reviewForms', $reviewForms);
+		$templateMgr->assign('emailVariables', array(
+			'reviewerName' => __('user.name'),
+			'responseDueDate' => __('reviewer.submission.responseDueDate'),
+			'reviewDueDate' => __('reviewer.submission.reviewDueDate'),
+			'submissionReviewUrl' => __('common.url'),
+			'reviewerUserName' => __('user.username'),
+		));
+		// Allow the default template
+		$templateKeys[] = $this->_getMailTemplateKey($request->getContext());
+
+		// Determine if the current user can use any custom templates defined.
+		$user = $request->getUser();
+		$roleDao = DAORegistry::getDAO('RoleDAO');
+
+		$userRoles = $roleDao->getByUserId($user->getId(), $submission->getContextId());
+		foreach ($userRoles as $userRole) {
+			if (in_array($userRole->getId(), array(ROLE_ID_MANAGER, ROLE_ID_SUB_EDITOR, ROLE_ID_ASSISTANT))) {
+				$emailTemplateDao = DAORegistry::getDAO('EmailTemplateDAO');
+				$customTemplates = $emailTemplateDao->getCustomTemplateKeys(Application::getContextAssocType(), $submission->getContextId());
+				$templateKeys = array_merge($templateKeys, $customTemplates);
+				break;
+			}
+		}
+
+		foreach ($templateKeys as $templateKey) {
+			$template = new SubmissionMailTemplate($submission, $templateKey, null, null, null, false);
+			$template->assignParams(array());
+			$templates[$templateKey] = $template->getSubject();
+		}
+
+		$templateMgr->assign('templates', $templates);
+
+		// Get the reviewer user groups for the create new reviewer/enroll existing user tabs
+		$context = $request->getContext();
+		$userGroupDao = DAORegistry::getDAO('UserGroupDAO'); /* @var $userGroupDao UserGroupDAO */
+		$reviewRound = $this->getReviewRound();
+		$reviewerUserGroups = $userGroupDao->getUserGroupsByStage($context->getId(), $reviewRound->getStageId(), false, false, ROLE_ID_REVIEWER);
+		$userGroups = array();
+		while($userGroup = $reviewerUserGroups->next()) {
+			$userGroups[$userGroup->getId()] = $userGroup->getLocalizedName();
+		}
+
+		$this->setData('userGroups', $userGroups);
+		return parent::fetch($request);
+	}
+
+	/**
+	 * Assign form data to user-submitted data.
+	 * @see Form::readInputData()
+	 */
+	function readInputData() {
+		$this->readUserVars(array(
+			'selectionType',
+			'submissionId',
+			'template',
+			'personalMessage',
+			'responseDueDate',
+			'reviewDueDate',
+			'reviewMethod',
+			'skipEmail',
+			'keywords',
+			'interests',
+			'reviewRoundId',
+			'stageId',
+			'selectedFiles',
+			'reviewFormId',
+		));
+	}
+
+	/**
+	 * Save review assignment
+	 * @param $args array
+	 * @param $request PKPRequest
+	 */
+	function execute($args, $request) {
+		$submission = $this->getSubmission();
+		$context = $request->getContext();
+
+		$currentReviewRound = $this->getReviewRound();
+		$stageId = $currentReviewRound->getStageId();
+		$reviewDueDate = $this->getData('reviewDueDate');
+		$responseDueDate = $this->getData('responseDueDate');
+
+		// Get reviewer id and validate it.
+		$reviewerId = (int) $this->getData('reviewerId');
+
+		if (!$this->_isValidReviewer($context, $submission, $currentReviewRound, $reviewerId)) {
+			fatalError('Invalid reviewer id.');
+		}
+
+		$reviewMethod = (int) $this->getData('reviewMethod');
+
+		import('lib.pkp.classes.submission.action.EditorAction');
+		$editorAction = new EditorAction();
+		$editorAction->addReviewer($request, $submission, $reviewerId, $currentReviewRound, $reviewDueDate, $responseDueDate, $reviewMethod);
+
+		// Get the reviewAssignment object now that it has been added.
+		$reviewAssignmentDao = DAORegistry::getDAO('ReviewAssignmentDAO'); /* @var $reviewAssignmentDao ReviewAssignmentDAO */
+		$reviewAssignment = $reviewAssignmentDao->getReviewAssignment($currentReviewRound->getId(), $reviewerId, $currentReviewRound->getRound(), $stageId);
+		$reviewAssignment->setDateNotified(Core::getCurrentDate());
+		$reviewAssignment->setCancelled(0);
+		$reviewAssignment->stampModified();
+
+		// Ensure that the review form ID is valid, if specified
+		$reviewFormId = (int) $this->getData('reviewFormId');
+		$reviewFormDao = DAORegistry::getDAO('ReviewFormDAO');
+		$reviewForm = $reviewFormDao->getById($reviewFormId, Application::getContextAssocType(), $context->getId());
+		$reviewAssignment->setReviewFormId($reviewForm?$reviewFormId:null);
+
+		$reviewAssignmentDao->updateObject($reviewAssignment);
+
+		// Grant access for this review to all selected files.
+		$submissionFileDao = DAORegistry::getDAO('SubmissionFileDAO');
+		import('lib.pkp.classes.submission.SubmissionFile'); // File constants
+		$submissionFiles = $submissionFileDao->getLatestRevisionsByReviewRound($currentReviewRound, SUBMISSION_FILE_REVIEW_FILE);
+		$selectedFiles = (array) $this->getData('selectedFiles');
+		$reviewFilesDao = DAORegistry::getDAO('ReviewFilesDAO');
+		foreach ($submissionFiles as $submissionFile) {
+			if (in_array($submissionFile->getFileId(), $selectedFiles)) {
+				$reviewFilesDao->grant($reviewAssignment->getId(), $submissionFile->getFileId());
+			}
+		}
+
+
+		// Notify the reviewer via email.
+		import('lib.pkp.classes.mail.SubmissionMailTemplate');
+		$templateKey = $this->getData('template');
+		$mail = new SubmissionMailTemplate($submission, $templateKey, null, null, null, false);
+
+		if ($mail->isEnabled() && !$this->getData('skipEmail')) {
+			$userDao = DAORegistry::getDAO('UserDAO'); /* @var $userDao UserDAO */
+			$reviewer = $userDao->getById($reviewerId);
+			$user = $request->getUser();
+			$mail->addRecipient($reviewer->getEmail(), $reviewer->getFullName());
+			$mail->setBody($this->getData('personalMessage'));
+			$dispatcher = $request->getDispatcher();
+
+			// Set the additional arguments for the one click url
+			$reviewUrlArgs = array('submissionId' => $this->getSubmissionId());
+			if ($context->getSetting('reviewerAccessKeysEnabled')) {
+				import('lib.pkp.classes.security.AccessKeyManager');
+				$accessKeyManager = new AccessKeyManager();
+				$expiryDays = $context->getSetting('numWeeksPerReview') + 4 * 7;
+				$accessKey = $accessKeyManager->createKey($context->getId(), $reviewerId, $reviewAssignment->getId(), $expiryDays);
+				$reviewUrlArgs = array_merge($reviewUrlArgs, array('reviewId' => $reviewAssignment->getId(), 'key' => $accessKey));
+			}
+
+			// Assign the remaining parameters
+			$mail->assignParams(array(
+				'reviewerName' => $reviewer->getFullName(),
+				'responseDueDate' => $responseDueDate,
+				'reviewDueDate' => $reviewDueDate,
+				'reviewerUserName' => $reviewer->getUsername(),
+				'submissionReviewUrl' => $dispatcher->url($request, ROUTE_PAGE, null, 'reviewer', 'submission', null, $reviewUrlArgs)
+			));
+			$mail->send($request);
+		}
+
+		return $reviewAssignment;
+	}
+
+
+	//
+	// Protected methods.
+	//
+	/**
+	 * Get the link action that fetchs the advanced search form content
+	 * @param $request Request
+	 * @return LinkAction
+	 */
+	function getAdvancedSearchAction($request) {
+		$reviewRound = $this->getReviewRound();
+
+		$actionArgs['submissionId'] = $this->getSubmissionId();
+		$actionArgs['stageId'] = $reviewRound->getStageId();
+		$actionArgs['reviewRoundId'] = $reviewRound->getId();
+		$actionArgs['selectionType'] = REVIEWER_SELECT_ADVANCED_SEARCH;
+
+		return new LinkAction(
+			'addReviewer',
+			new AjaxAction($request->url(null, null, 'reloadReviewerForm', null, $actionArgs)),
+			__('editor.submission.backToSearch'),
+			'return'
+		);
+	}
+
+
+	//
+	// Private helper methods
+	//
+	/**
+	 * Check if a given user id is enrolled in reviewer user group.
+	 * @param $context Context
+	 * @param $submission Submission
+	 * @param $reviewRound ReviewRound
+	 * @param $reviewerId int
+	 * @return boolean
+	 */
+	function _isValidReviewer($context, $submission, $reviewRound, $reviewerId) {
+		$userDao = DAORegistry::getDAO('UserDAO'); /* @var $userDao UserDAO */
+		$reviewerFactory = $userDao->getReviewersNotAssignedToSubmission($context->getId(), $submission->getId(), $reviewRound);
+		$reviewersArray = $reviewerFactory->toAssociativeArray();
+		if (array_key_exists($reviewerId, $reviewersArray)) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Get the email template key depending on if reviewer one click access is
+	 * enabled or not.
+	 *
+	 * @param mixed $context Context
+	 * @return int Email template key
+	 */
+	function _getMailTemplateKey($context) {
+		$templateKey = 'REVIEW_REQUEST';
+		if ($context->getSetting('reviewerAccessKeysEnabled')) {
+			$templateKey = 'REVIEW_REQUEST_ONECLICK';
+		}
+
+		return $templateKey;
+	}
+}
+
+?>

--- a/journal-machinery/ojs-3.0.1/plugins/themes/nsamr/controllers/grid/users/reviewer/form/ReviewerForm.inc.php
+++ b/journal-machinery/ojs-3.0.1/plugins/themes/nsamr/controllers/grid/users/reviewer/form/ReviewerForm.inc.php
@@ -174,14 +174,14 @@ class ReviewerForm extends Form {
 		} else {
 			$numWeeks = (int) $context->getSetting('numWeeksPerReview');
 			if ($numWeeks<=0) $numWeeks=4;
-			$reviewDueDate = strftime(Config::getVar('general', 'date_format_short'), strtotime('+' . $numWeeks . ' week'));
+			$reviewDueDate = strftime(Config::getVar('general', 'date_format_short'), strtotime('+' . $numWeeks . ' day'));
 		}
 		if (isset($reviewAssignment) && $reviewAssignment->getResponseDueDate() != null) {
 			$responseDueDate = strftime(Config::getVar('general', 'date_format_short'), strtotime($reviewAssignment->getResponseDueDate()));
 		} else {
 			$numWeeks = (int) $context->getSetting('numWeeksPerResponse');
 			if ($numWeeks<=0) $numWeeks=3;
-			$responseDueDate = strftime(Config::getVar('general', 'date_format_short'), strtotime('+' . $numWeeks . ' week'));
+			$responseDueDate = strftime(Config::getVar('general', 'date_format_short'), strtotime('+' . $numWeeks . ' day'));
 		}
 
 		// Get the currently selected reviewer selection type to show the correct tab if we're re-displaying the form

--- a/journal-machinery/ojs-3.0.1/plugins/themes/nsamr/controllers/tab/settings/reviewStage/form/PKPReviewStageForm.inc.php
+++ b/journal-machinery/ojs-3.0.1/plugins/themes/nsamr/controllers/tab/settings/reviewStage/form/PKPReviewStageForm.inc.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @file controllers/tab/settings/reviewStage/form/PKPReviewStageForm.inc.php
+ *
+ * Copyright (c) 2014-2016 Simon Fraser University Library
+ * Copyright (c) 2003-2016 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @class ReviewStageForm
+ * @ingroup controllers_tab_settings_reviewStage_form
+ *
+ * @brief Form to edit review stage settings.
+ */
+
+import('lib.pkp.classes.controllers.tab.settings.form.ContextSettingsForm');
+
+class PKPReviewStageForm extends ContextSettingsForm {
+
+	/**
+	 * Constructor.
+	 */
+	function __construct($wizardMode = false, $settings = array(), $template = 'controllers/tab/settings/reviewStage/form/reviewStageForm.tpl') {
+		parent::__construct(
+			array_merge(
+				$settings,
+				array(
+					'reviewGuidelines' => 'string',
+					'competingInterests' => 'string',
+					'numWeeksPerResponse' => 'int',
+					'numWeeksPerReview' => 'int',
+					'numDaysBeforeInviteReminder' => 'int',
+					'numDaysBeforeSubmitReminder' => 'int',
+					// 'rateReviewerOnQuality' => 'bool', /* http://github.com/pkp/pkp-lib/issues/372 */
+					'showEnsuringLink' => 'bool',
+					'reviewerCompetingInterestsRequired' => 'bool',
+					'defaultReviewMode' => 'int',
+				)
+			),
+			$template,
+			$wizardMode
+		);
+	}
+
+
+	//
+	// Implement template methods from Form.
+	//
+	/**
+	 * @copydoc Form::getLocaleFieldNames()
+	 */
+	function getLocaleFieldNames() {
+		return array('reviewGuidelines', 'competingInterests');
+	}
+
+	/**
+	 * @copydoc ContextSettingsForm::fetch()
+	 */
+	function fetch($request) {
+		$params = array();
+
+		// Ensuring blind review link.
+		import('lib.pkp.classes.linkAction.request.ConfirmationModal');
+		import('lib.pkp.classes.linkAction.LinkAction');
+		$params['ensuringLink'] = new LinkAction(
+			'showReviewPolicy',
+			new ConfirmationModal(
+				__('review.blindPeerReview'),
+				__('review.ensuringBlindReview'), 'modal_information', null, null, true, MODAL_WIDTH_DEFAULT),
+			__('manager.setup.reviewOptions.showBlindReviewLink')
+		);
+
+		$params['scheduledTasksDisabled'] = (Config::getVar('general', 'scheduled_tasks')) ? false : true;
+
+		$templateMgr = TemplateManager::getManager($request);
+		$templateMgr->assign(array(
+			'numDaysBeforeInviteReminderValues' => array_combine(range(1, 10), range(1, 10)),
+			'numDaysBeforeSubmitReminderValues' => array_combine(range(1, 10), range(1, 10))
+		));
+
+		$reviewAssignmentDao = DAORegistry::getDAO('ReviewAssignmentDAO');
+		$templateMgr->assign('reviewMethodOptions', $reviewAssignmentDao->getReviewMethodsTranslationKeys());
+
+		return parent::fetch($request, $params);
+	}
+}
+
+?>

--- a/journal-machinery/ojs-3.0.1/plugins/themes/nsamr/locale/en_US/locale.xml
+++ b/journal-machinery/ojs-3.0.1/plugins/themes/nsamr/locale/en_US/locale.xml
@@ -14,4 +14,6 @@
 <locale name="en_US" full_name="U.S. English">
 	<message key="plugins.themes.nsamr.name">NSAMR Theme</message>
 	<message key="plugins.themes.nsamr.description">This theme is a child theme of the bootstrap3 theme.</message>
+  <message key="manager.setup.reviewOptions.numWeeksPerResponse">Days allowed to accept or decline a review request</message>
+  <message key="manager.setup.reviewOptions.numWeeksPerReview">Days allowed for review completion</message>
 </locale>

--- a/journal-machinery/ojs-3.0.1/plugins/themes/nsamr/registry/journalSettings.xml
+++ b/journal-machinery/ojs-3.0.1/plugins/themes/nsamr/registry/journalSettings.xml
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  * registry/journalSettings.xml
+  *
+  * Copyright (c) 2014-2016 Simon Fraser University Library
+  * Copyright (c) 2003-2016 John Willinsky
+  * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+  *
+  * Default journal settings.
+  -->
+
+<!DOCTYPE journal_settings [
+	<!ELEMENT journal_settings (setting+)>
+	<!ELEMENT setting (name, value)>
+	<!ATTLIST setting type (int|string|object|bool) #REQUIRED>
+	<!ATTLIST setting locale (0|1) #REQUIRED>
+	<!ELEMENT name (#PCDATA)>
+	<!ELEMENT value (#PCDATA | array)*>
+	<!ELEMENT element (#PCDATA | array)*>
+	<!ATTLIST element key CDATA #IMPLIED>
+	<!ELEMENT array (element+)>
+]>
+
+<journal_settings>
+	<setting type="int" locale="0">
+		<name>numPageLinks</name>
+		<value>10</value>
+	</setting>
+	<setting type="int" locale="0">
+		<name>itemsPerPage</name>
+		<value>25</value>
+	</setting>
+	<setting type="int" locale="0">
+		<name>numWeeksPerReview</name>
+		<value>4</value>
+	</setting>
+	<setting type="int" locale="0">
+		<name>defaultReviewMode</name>
+		<value>2</value><!-- SUBMISSION_REVIEW_METHOD_DOUBLEBLIND -->
+	</setting>
+	<setting type="string" locale="1">
+		<name>privacyStatement</name>
+		<value>{translate key="default.journalSettings.privacyStatement"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>openAccessPolicy</name>
+		<value>{translate key="default.journalSettings.openAccessPolicy"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>authorSelfArchivePolicy</name>
+		<value>{translate key="default.journalSettings.authorSelfArchivePolicy"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>copyeditInstructions</name>
+		<value>{translate key="default.journalSettings.copyeditInstructions"}</value>
+	</setting>
+	<setting type="string" locale="0">
+		<name>emailSignature</name>
+		<value>{translate key="default.journalSettings.emailSignature"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>proofInstructions</name>
+		<value>{translate key="default.journalSettings.proofingInstructions"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>refLinkInstructions</name>
+		<value>{translate key="default.journalSettings.refLinkInstructions"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>readerInformation</name>
+		<value>{translate key="default.journalSettings.forReaders"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>authorInformation</name>
+		<value>{translate key="default.journalSettings.forAuthors"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>librarianInformation</name>
+		<value>{translate key="default.journalSettings.forLibrarians"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>lockssLicense</name>
+		<value>{translate key="default.journalSettings.lockssLicense"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>clockssLicense</name>
+		<value>{translate key="default.journalSettings.clockssLicense"}</value>
+	</setting>
+	<setting type="object" locale="0">
+		<name>supportedFormLocales</name>
+		<value>
+			<array>
+				<element>{$primaryLocale}</element>
+			</array>
+		</value>
+	</setting>
+	<setting type="object" locale="0">
+		<name>supportedSubmissionLocales</name>
+		<value>
+			<array>
+				<element>{$primaryLocale}</element>
+			</array>
+		</value>
+	</setting>
+	<setting type="object" locale="1">
+		<name>submissionChecklist</name>
+		<value>
+			<array>
+				<element>
+					<array>
+						<element key="content">{translate key="default.journalSettings.checklist.notPreviouslyPublished"}</element>
+						<element key="order">1</element>
+					</array>
+				</element>
+				<element>
+					<array>
+						<element key="content">{translate key="default.journalSettings.checklist.fileFormat"}</element>
+						<element key="order">2</element>
+					</array>
+				</element>
+				<element>
+					<array>
+						<element key="content">{translate key="default.journalSettings.checklist.addressesLinked"}</element>
+						<element key="order">3</element>
+					</array>
+				</element>
+				<element>
+					<array>
+						<element key="content">{translate key="default.journalSettings.checklist.submissionAppearance"}</element>
+						<element key="order">4</element>
+					</array>
+				</element>
+				<element>
+					<array>
+						<element key="content">{translate key="default.journalSettings.checklist.bibliographicRequirements"}</element>
+						<element key="order">5</element>
+					</array>
+				</element>
+			</array>
+		</value>
+	</setting>
+	<setting type="bool" locale="0">
+		<name>rtAbstract</name>
+		<value>true</value>
+	</setting>
+	<setting type="bool" locale="0">
+		<name>rtCaptureCite</name>
+		<value>true</value>
+	</setting>
+	<setting type="bool" locale="0">
+		<name>rtViewMetadata</name>
+		<value>true</value>
+	</setting>
+	<setting type="bool" locale="0">
+		<name>rtSupplementaryFiles</name>
+		<value>true</value>
+	</setting>
+	<setting type="bool" locale="0">
+		<name>rtPrinterFriendly</name>
+		<value>true</value>
+	</setting>
+	<setting type="bool" locale="0">
+		<name>rtDefineTerms</name>
+		<value>true</value>
+	</setting>
+	<setting type="bool" locale="0">
+		<name>rtAddComment</name>
+		<value>true</value>
+	</setting>
+	<setting type="bool" locale="0">
+		<name>rtEmailAuthor</name>
+		<value>true</value>
+	</setting>
+	<setting type="bool" locale="0">
+		<name>rtEmailOthers</name>
+		<value>true</value>
+	</setting>
+	<setting type="int" locale="0">
+		<name>submissionFee</name>
+		<value>0</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>submissionFeeName</name>
+		<value>{translate key="default.journalSettings.submissionFee"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>submissionFeeDescription</name>
+		<value>{translate key="default.journalSettings.submissionFeeDescription"}</value>
+	</setting>
+	<setting type="int" locale="0">
+		<name>fastTrackFee</name>
+		<value>0</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>fastTrackFeeName</name>
+		<value>{translate key="default.journalSettings.fastTrackFee"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>fastTrackFeeDescription</name>
+		<value>{translate key="default.journalSettings.fastTrackFeeDescription"}</value>
+	</setting>
+	<setting type="int" locale="0">
+		<name>publicationFee</name>
+		<value>0</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>publicationFeeName</name>
+		<value>{translate key="default.journalSettings.publicationFee"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>publicationFeeDescription</name>
+		<value>{translate key="default.journalSettings.publicationFeeDescription"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>waiverPolicy</name>
+		<value>{translate key="default.journalSettings.waiverPolicy"}</value>
+	</setting>
+	<setting type="int" locale="0">
+		<name>purchaseArticleFee</name>
+		<value>0</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>purchaseArticleFeeName</name>
+		<value>{translate key="default.journalSettings.purchaseArticleFee"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>purchaseArticleFeeDescription</name>
+		<value>{translate key="default.journalSettings.purchaseArticleFeeDescription"}</value>
+	</setting>
+	<setting type="int" locale="0">
+		<name>membershipFee</name>
+		<value>0</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>membershipFeeName</name>
+		<value>{translate key="default.journalSettings.membershipFee"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>membershipFeeDescription</name>
+		<value>{translate key="default.journalSettings.membershipFeeDescription"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>donationFeeName</name>
+		<value>{translate key="default.journalSettings.donationFee"}</value>
+	</setting>
+	<setting type="string" locale="1">
+		<name>donationFeeDescription</name>
+		<value>{translate key="default.journalSettings.donationFeeDescription"}</value>
+	</setting>
+	<setting type="bool" locale="1">
+		<name>metaCitations</name>
+		<value>1</value>
+	</setting>
+	<setting type="string" locale="0">
+		<name>themePluginPath</name>
+		<value>default</value>
+	</setting>
+	<setting type="bool" locale="0">
+		<name>keywordsEnabledSubmission</name>
+		<value>1</value>
+	</setting>
+	<setting type="bool" locale="0">
+		<name>keywordsEnabledWorkflow</name>
+		<value>1</value>
+	</setting>
+</journal_settings>


### PR DESCRIPTION
@srees95 I can turn on reminder emails to poke non-repliers any number of days AFTER the deadline, but changing this to have a BEFORE option is a little harder. If you want this, then you need to check the text of the emails (if you haven't already)